### PR TITLE
Limit `prConcurrentLimit=1`

### DIFF
--- a/default.json
+++ b/default.json
@@ -25,7 +25,7 @@
         "github>dintero/renovate-config:groupTestingLibrary",
         "github>dintero/renovate-config:groupVite"
     ],
-    "prConcurrentLimit": 5,
+    "prConcurrentLimit": 1,
     "labels": ["dependencies"],
     "printConfig": true,
     "timezone": "Europe/Oslo",


### PR DESCRIPTION
We will now try to run renovate multiple times during the work day
so it make sense to create fewer

Rel: https://github.com/Dintero/ecs-arch-continous-deployment/pull/1513
