### PR TITLE
Add group for aws-sdk-go/aws-sdk-go-2

### DIFF
--- a/default.json
+++ b/default.json
@@ -7,6 +7,7 @@
         "config:recommended",
         "github>dintero/renovate-config:groupAwsCdk",
         "github>dintero/renovate-config:groupAwsSdk",
+        "github>dintero/renovate-config:groupAwsSdkGo.json",
         "github>dintero/renovate-config:groupBoto3AwsCli.json",
         "github>dintero/renovate-config:groupEslint",
         "github>dintero/renovate-config:groupJest",

--- a/groupAwsSdkGo.json
+++ b/groupAwsSdkGo.json
@@ -1,0 +1,15 @@
+{
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "description": "Group major updates of aws-sdk-go",
+    "packageRules": [
+        {
+            "groupName": "aws/aws-sdk-go",
+            "matchPackageNames": [
+                "github.com/aws/aws-sdk-go",
+                "github.com/aws/aws-sdk-go-v2"
+            ],
+            "matchUpdateTypes": ["major"],
+            "schedule": ["before 11am on Monday"]
+        }
+    ]
+}


### PR DESCRIPTION
Limit the upgrade of aws-sdk-go packages to Mondays
