### PR TITLE
Fix warnings reported by renovate-config-validator

### DIFF
--- a/groupAwsCdk.json
+++ b/groupAwsCdk.json
@@ -5,8 +5,12 @@
         {
             "extends": ["schedule:monthly"],
             "groupName": "@aws-cdk packages",
-            "matchPackagePatterns": ["aws-cdk", "aws-cdk-lib", "aws-cdk-local"],
-            "minimumReleaseAge": "10 days"
+            "minimumReleaseAge": "10 days",
+            "matchPackageNames": [
+                "/aws-cdk/",
+                "/aws-cdk-lib/",
+                "/aws-cdk-local/"
+            ]
         }
     ]
 }

--- a/groupAwsSdk.json
+++ b/groupAwsSdk.json
@@ -5,8 +5,8 @@
         {
             "extends": ["schedule:monthly"],
             "groupName": "@aws-sdk packages",
-            "matchPackagePatterns": ["@aws-sdk", "@types/aws"],
-            "minimumReleaseAge": "10 days"
+            "minimumReleaseAge": "10 days",
+            "matchPackageNames": ["/@aws-sdk/", "/@types/aws/"]
         }
     ]
 }

--- a/groupBoto3AwsCli.json
+++ b/groupBoto3AwsCli.json
@@ -5,8 +5,8 @@
         {
             "extends": ["schedule:monthly"],
             "groupName": "boto3 / awscli",
-            "matchPackagePatterns": ["awscli", "boto3", "botocore"],
-            "minimumReleaseAge": "10 days"
+            "minimumReleaseAge": "10 days",
+            "matchPackageNames": ["/awscli/", "/boto3/", "/botocore/"]
         }
     ]
 }

--- a/groupEslint.json
+++ b/groupEslint.json
@@ -5,16 +5,16 @@
         {
             "extends": ["schedule:monthly"],
             "groupName": "eslint packages",
-            "matchPackagePatterns": [
-                "@eslint/*",
-                "@typescript-eslint/*",
-                "eslint",
-                "eslint-*",
-                "prettier",
-                "prettier-*",
-                "typescript-eslint"
-            ],
-            "minimumReleaseAge": "10 days"
+            "minimumReleaseAge": "10 days",
+            "matchPackageNames": [
+                "/@eslint/*/",
+                "/@typescript-eslint/*/",
+                "/eslint/",
+                "/eslint-*/",
+                "/prettier/",
+                "/prettier-*/",
+                "/typescript-eslint/"
+            ]
         }
     ]
 }

--- a/groupJest.json
+++ b/groupJest.json
@@ -10,14 +10,15 @@
         {
             "extends": ["schedule:monthly"],
             "groupName": "Jest packages",
-            "matchPackagePrefixes": ["@types/jest-", "jest-"],
             "matchPackageNames": [
                 "@types/jest",
                 "ts-jest",
                 "@types/supertest",
-                "supertest"
-            ],
-            "matchPackagePatterns": ["@cucumber/*"]
+                "supertest",
+                "@types/jest-{/,}**",
+                "jest-{/,}**",
+                "/@cucumber/*/"
+            ]
         }
     ]
 }

--- a/groupJsonwebtoken.json
+++ b/groupJsonwebtoken.json
@@ -4,7 +4,7 @@
     "packageRules": [
         {
             "groupName": "jsonwebtoken packages",
-            "matchPackagePatterns": ["@types/jsonwebtoken", "jsonwebtoken"]
+            "matchPackageNames": ["/@types/jsonwebtoken/", "/jsonwebtoken/"]
         }
     ]
 }

--- a/groupLodash.json
+++ b/groupLodash.json
@@ -4,7 +4,7 @@
     "packageRules": [
         {
             "groupName": "lodash packages",
-            "matchPackagePrefixes": ["lodash", "@types/lodash"]
+            "matchPackageNames": ["lodash{/,}**", "@types/lodash{/,}**"]
         }
     ]
 }

--- a/groupMantine.json
+++ b/groupMantine.json
@@ -4,7 +4,7 @@
     "packageRules": [
         {
             "groupName": "@mantine packages",
-            "matchPackagePatterns": ["@mantine/*"]
+            "matchPackageNames": ["/@mantine/*/"]
         }
     ]
 }

--- a/groupNodeFetch.json
+++ b/groupNodeFetch.json
@@ -4,8 +4,8 @@
     "packageRules": [
         {
             "groupName": "node-fetch packages",
-            "matchPackagePatterns": ["@types/node-fetch", "node-fetch"],
-            "allowedVersions": "<3.0.0"
+            "allowedVersions": "<3.0.0",
+            "matchPackageNames": ["/@types/node-fetch/", "/node-fetch/"]
         }
     ]
 }

--- a/groupPino.json
+++ b/groupPino.json
@@ -4,7 +4,7 @@
     "packageRules": [
         {
             "groupName": "pino packages",
-            "matchPackagePrefixes": ["pino", "pino-"]
+            "matchPackageNames": ["pino{/,}**", "pino-{/,}**"]
         }
     ]
 }

--- a/groupReact.json
+++ b/groupReact.json
@@ -4,8 +4,11 @@
     "packageRules": [
         {
             "groupName": "React packages",
-            "matchPackagePrefixes": ["@types/react-", "react-"],
-            "matchPackageNames": ["@types/react"]
+            "matchPackageNames": [
+                "@types/react",
+                "@types/react-{/,}**",
+                "react-{/,}**"
+            ]
         }
     ]
 }

--- a/groupRollup.json
+++ b/groupRollup.json
@@ -4,7 +4,7 @@
     "packageRules": [
         {
             "groupName": "@rollup packages",
-            "matchPackagePrefixes": ["@rollup/"]
+            "matchPackageNames": ["@rollup/{/,}**"]
         }
     ]
 }

--- a/groupSentry.json
+++ b/groupSentry.json
@@ -2,9 +2,6 @@
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "description": "Group and schedule all sentry updates.",
     "packageRules": [
-        {
-            "groupName": "@sentry",
-            "matchPackagePatterns": ["@sentry/*"]
-        }
+        { "groupName": "@sentry", "matchPackageNames": ["/@sentry/*/"] }
     ]
 }

--- a/groupServerless.json
+++ b/groupServerless.json
@@ -1,10 +1,9 @@
 {
-    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "description": "Group and schedule all serverless related updates.",
     "packageRules": [
         {
             "groupName": "serverless packages",
-            "matchPackagePatterns": ["serverless", "serverless-*"]
+            "matchPackageNames": ["/serverless/", "/serverless-*/"]
         }
     ]
 }

--- a/groupSmithy.json
+++ b/groupSmithy.json
@@ -4,7 +4,7 @@
     "packageRules": [
         {
             "groupName": "smithy packages",
-            "matchPackagePrefixes": ["@smithy"]
+            "matchPackageNames": ["@smithy{/,}**"]
         }
     ]
 }

--- a/groupStorybook.json
+++ b/groupStorybook.json
@@ -4,8 +4,7 @@
     "packageRules": [
         {
             "groupName": "Storybook packages",
-            "matchPackagePrefixes": ["@storybook/"],
-            "matchPackageNames": ["storybook"]
+            "matchPackageNames": ["storybook", "@storybook/{/,}**"]
         }
     ]
 }

--- a/groupTestingLibrary.json
+++ b/groupTestingLibrary.json
@@ -4,7 +4,7 @@
     "packageRules": [
         {
             "groupName": "@testing-library packages",
-            "matchPackagePrefixes": ["@testing-library/*"]
+            "matchPackageNames": ["@testing-library/*{/,}**"]
         }
     ]
 }

--- a/groupVite.json
+++ b/groupVite.json
@@ -4,10 +4,10 @@
     "packageRules": [
         {
             "groupName": "vite packages",
-            "matchPackagePatterns": [
-                "@vitejs/plugin-react-swc",
-                "vite",
-                "vite-*"
+            "matchPackageNames": [
+                "/@vitejs/plugin-react-swc/",
+                "/vite/",
+                "/vite-*/"
             ]
         }
     ]

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "private": true,
     "scripts": {
         "lint": "prettier -c .",
-        "test": "renovate-config-validator group*.json default.json"
+        "test": "renovate-config-validator --strict group*.json default.json"
     },
     "devDependencies": {
         "prettier": "3.3.3",


### PR DESCRIPTION
Enable `--strict` validation so any warnings will in the future break
the PR build

Fixes: https://github.com/Dintero/renovate-config/issues/54
