### PR TITLE
groupBoto3AwsCli: Include s3transfer

### DIFF
--- a/groupBoto3AwsCli.json
+++ b/groupBoto3AwsCli.json
@@ -6,7 +6,12 @@
             "extends": ["schedule:monthly"],
             "groupName": "boto3 / awscli",
             "minimumReleaseAge": "10 days",
-            "matchPackageNames": ["/awscli/", "/boto3/", "/botocore/"]
+            "matchPackageNames": [
+                "/awscli/",
+                "/boto3/",
+                "/botocore/",
+                "/s3transfer/"
+            ]
         }
     ]
 }


### PR DESCRIPTION
awscli have a dependency on s3transfer so it make sense to bump them
together
