### PR TITLE
chore(ci): Update node-version to lts

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,7 +14,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: "lts/*"
           cache: npm
       - run: yarn install
       - run: yarn run lint


### PR DESCRIPTION
Use lts node version when building PR requests

Blocks: https://github.com/Dintero/renovate-config/pull/68
